### PR TITLE
#KDSK-127 모니터링 지도 기능 보완

### DIFF
--- a/app/src/components/MapBox.js
+++ b/app/src/components/MapBox.js
@@ -72,6 +72,9 @@ function MapBox({ geojson }) {
     centerId: null,
   });
 
+  // 시·군·구 내에 어린이집 이상행동 검색 결과가 없으면 에러창 출력
+  const [noCdrResult, setNoCdrResult] = useState(false);
+
   // geojsonData 를 dependency 배열에 넣으면 시군구 기능이 정상적으로 동작하지 않음
   useEffect(() => {
     dispatch(resetToSidoDistrict(districtArea));
@@ -133,7 +136,11 @@ function MapBox({ geojson }) {
           const sggnmFind = geojsonData.features.find(
             (data) => data.properties.sggnm === selectedDistrictInfo.name
           );
-          if (sggnmFind) dispatch(sggClick(selectedDistrictInfo));
+          if (!sggnmFind) return;
+
+          dispatch(sggClick(selectedDistrictInfo)).then(() =>
+            setNoCdrResult(true)
+          );
         }
       }
     } catch (e) {
@@ -178,6 +185,7 @@ function MapBox({ geojson }) {
       open: true,
       centerId: null,
     });
+    setNoCdrResult(false);
   }, [dispatch, districtArea]);
 
   const resetToSggClick = useCallback(() => {
@@ -187,6 +195,7 @@ function MapBox({ geojson }) {
       open: true,
       centerId: null,
     });
+    setNoCdrResult(false);
   }, [dispatch, geojsonData, sidoName]);
 
   if (error) <div>지도 오류 발생</div>;
@@ -260,6 +269,22 @@ function MapBox({ geojson }) {
             ))}
         </div>
       </ReactMapGL>
+      {/* 검색결과 에러창 */}
+      {noCdrResult && cdrCentersInfo.length === 0 && (
+        <div className="noResult-modal">
+          <section className="noResult-modal-section">
+            ⚠️ 검색결과가 없습니다.
+            <Button
+              variant="contained"
+              color="primary"
+              disableElevation
+              onClick={resetToSggClick}
+            >
+              확인
+            </Button>
+          </section>
+        </div>
+      )}
       {/* 어린이집 이상행동 개수에 기반한 범주 */}
       {level && (
         <>

--- a/app/src/components/MapBox.js
+++ b/app/src/components/MapBox.js
@@ -18,6 +18,7 @@ import {
 import { resetCdrCenter, setCdrCenter } from "../modules/cdrCenter";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
 
+import { Button } from "@material-ui/core";
 import MapBoxCategory from "./MapBoxCategory";
 import districtViewport from "../utils/districtViewport";
 
@@ -234,11 +235,22 @@ function MapBox({ geojson }) {
         </div>
       </ReactMapGL>
       {/* 어린이집 개수에 기반한 범주 */}
-      {level && <MapBoxCategory level={level} />}
-      {/* 도, 광역시 기준으로 초기화하는 버튼 */}
-      <button onClick={resetClickHandler} className="reset-button">
-        Reset
-      </button>
+      {level && (
+        <>
+          {/* 도, 광역시 기준으로 초기화하는 버튼 */}
+          <MapBoxCategory level={level}>
+            <Button
+              className="reset-button"
+              variant="contained"
+              color="primary"
+              disableElevation
+              onClick={resetClickHandler}
+            >
+              검색 초기화
+            </Button>
+          </MapBoxCategory>
+        </>
+      )}
     </>
   );
 }

--- a/app/src/components/MapBox.js
+++ b/app/src/components/MapBox.js
@@ -8,7 +8,8 @@ import {
 } from "../utils/mapStyle";
 import {
   markerClick,
-  resetDistrict,
+  resetToSggDistrict,
+  resetToSidoDistrict,
   setGeojsonData,
   sggClick,
   sggHover,
@@ -38,12 +39,12 @@ function MapBox({ geojson }) {
    * MapBox 컴포넌트에서 사용하는 상태
    * - level : 도, 광역시 / 시,군,구의 기능을 구분
    * - popupInfo : hover 이벤트 간 발생하는 정보
-   * - geojsonData : 행정구역을 렌더링하기 위핸 geojson 데이터
+   * - geojsonData : 행정구역을 렌더링하기 위한 geojson 데이터
    * - cdrCentersInfo : 시,군,구 내에 있는 어린이집 정보
    * - error : 발생한 에러
    */
   const {
-    data: { level, popupInfo, geojsonData, cdrCentersInfo },
+    data: { level, popupInfo, sidoName, geojsonData, cdrCentersInfo },
     error,
   } = useSelector((state) => state.mapboxEventReducer, shallowEqual);
   const dispatch = useDispatch();
@@ -68,7 +69,7 @@ function MapBox({ geojson }) {
   // geojsonData 를 dependency 배열에 넣으면 시군구 기능이 정상적으로 동작하지 않음
   /* eslint-disable */
   useEffect(() => {
-    dispatch(resetDistrict(districtArea));
+    dispatch(resetToSidoDistrict(districtArea));
     if (!geojsonData) dispatch(setGeojsonData(districtArea));
 
     return {
@@ -151,7 +152,7 @@ function MapBox({ geojson }) {
    * Reset 버튼 click 이벤트 핸들러
    * - level과 geojson 데이터를 도, 광역시 기준으로 초기화
    */
-  const resetClickHandler = useCallback(() => {
+  const resetToSidoClick = useCallback(() => {
     setViewport({
       width: 770,
       height: 800,
@@ -159,9 +160,15 @@ function MapBox({ geojson }) {
       longitude: districtViewport["대한민국"].lng,
       zoom: districtViewport["대한민국"].zoom,
     });
-    dispatch(resetDistrict(districtArea));
+
+    dispatch(resetToSidoDistrict(districtArea));
     dispatch(resetCdrCenter());
   }, [dispatch, districtArea]);
+
+  const resetToSggClick = useCallback(() => {
+    dispatch(resetToSggDistrict(geojsonData, sidoName));
+    dispatch(resetCdrCenter());
+  }, [geojsonData, sidoName]);
 
   if (error) <div>지도 오류 발생</div>;
 
@@ -234,20 +241,30 @@ function MapBox({ geojson }) {
             ))}
         </div>
       </ReactMapGL>
-      {/* 어린이집 개수에 기반한 범주 */}
+      {/* 어린이집 이상행동 개수에 기반한 범주 */}
       {level && (
         <>
           {/* 도, 광역시 기준으로 초기화하는 버튼 */}
           <MapBoxCategory level={level}>
-            <Button
-              className="reset-button"
-              variant="contained"
-              color="primary"
-              disableElevation
-              onClick={resetClickHandler}
-            >
-              검색 초기화
-            </Button>
+            <div className="control-button">
+              <Button
+                variant="contained"
+                color="primary"
+                disableElevation
+                onClick={resetToSidoClick}
+              >
+                도·광역시
+              </Button>
+              <Button
+                variant="contained"
+                color="primary"
+                disableElevation
+                onClick={resetToSggClick}
+                disabled={level == 1}
+              >
+                시·군·구
+              </Button>
+            </div>
           </MapBoxCategory>
         </>
       )}

--- a/app/src/components/MapBoxCategory.js
+++ b/app/src/components/MapBoxCategory.js
@@ -11,7 +11,7 @@ import TextField from "@material-ui/core/TextField";
  * @param {Object} level 도, 광역시 / 시,군,구의 기능을 구분
  * @return {JSX.Element} 범주 컴포넌트
  */
-function MapBoxCategory({ level }) {
+function MapBoxCategory({ level, children }) {
   const { sidoControl, sggControl } = useSelector(
     (state) => state.mapboxCategoryReducer
   );
@@ -122,6 +122,7 @@ function MapBoxCategory({ level }) {
           );
         })}
       </form>
+      {children}
     </div>
   );
 }

--- a/app/src/containers/MapBoxSelectContainer.js
+++ b/app/src/containers/MapBoxSelectContainer.js
@@ -65,16 +65,16 @@ function MapBoxSelectContainer() {
           data={cdrCenter.data}
           className="cdrCenter-info"
         />
-        <a
-          className="cdrcenter-link"
-          href={
-            cdrCenter.data.web_page ? urlFormat(cdrCenter.data.web_page) : null
-          }
-          target="_blank"
-          rel="noreferrer"
-        >
-          어린이집 홈페이지 바로가기 <FiExternalLink />
-        </a>
+        {cdrCenter.data.web_page && (
+          <a
+            className="cdrcenter-link"
+            href={cdrCenter.data.web_page}
+            target="_blank"
+            rel="noreferrer"
+          >
+            어린이집 홈페이지 바로가기 <FiExternalLink />
+          </a>
+        )}
       </div>
       <h1>이상행동 정보</h1>
       <hr />

--- a/app/src/modules/mapbox.js
+++ b/app/src/modules/mapbox.js
@@ -22,8 +22,7 @@ export const fetchData = () => async (dispatch) => {
     );
     districts = districts.data;
 
-    // geojson 데이터에 어린이집 개수 property 추가
-    // Todo : geojson 데이터에 어린이집 사건·사고 property 추가
+    // geojson 데이터에 어린이집 사건·사고 개수 property 추가
     districtsGeojson.features.forEach((districtGeojson) => {
       districts.forEach((district) => {
         if (districtGeojson.properties.sidonm === district.district_name)

--- a/app/src/modules/mapboxEvent.js
+++ b/app/src/modules/mapboxEvent.js
@@ -4,7 +4,8 @@ const SET_GEOJSON_DATA = "mapboxEvent/SET_GEOJSON_DATA";
 const SET_HOVER_INFO = "mapboxEvent/SET_HOVER_INFO";
 const SIDO_CLICK = "mapboxEvent/SIDO_CLICK";
 const SGG_CLICK = "mapboxEvent/SGG_CLICK";
-const RESET_DISTRICT = "mapboxEvent/RESET";
+const RESET_TO_SIDO_DISTRICT = "mapboxEvent/RESET_TO_SIDO_DISTRICT";
+const RESET_TO_SGG_DISTRICT = "mapboxEvent/RESET_TO_SGG_DISTRICT";
 const MARKER_Click = "mapboxEvent/MARKER_Click";
 const ERROR = "mapboxEvent/ERROR";
 
@@ -151,9 +152,15 @@ export const sggClick = (selectedDistrictInfo) => async (dispatch) => {
  *
  * @param {Object} selectedDistrictInfo hover 중인 영역의 정보 (지역명, 코드)
  */
-export const resetDistrict = (geojsonData) => async (dispatch) => {
-  dispatch({ type: RESET_DISTRICT, payload: geojsonData });
-};
+export const resetToSidoDistrict = (geojson) => ({
+  type: RESET_TO_SIDO_DISTRICT,
+  payload: geojson,
+});
+
+export const resetToSggDistrict = (geojson, sidoName) => ({
+  type: RESET_TO_SGG_DISTRICT,
+  payload: { geojson, sidoName },
+});
 
 /**
  * 마커 클릭 이벤트를 처리하는 액션함수
@@ -238,8 +245,8 @@ export default function mapboxEventReducer(state = initialState, action) {
         },
         error: null,
       };
-    // reset 이벤트
-    case RESET_DISTRICT:
+    // 도, 광역시 기준 초기화
+    case RESET_TO_SIDO_DISTRICT:
       return {
         data: {
           ...state.data,
@@ -250,6 +257,19 @@ export default function mapboxEventReducer(state = initialState, action) {
           cdrCentersInfo: null,
         },
       };
+    // 시,군,구 기준 초기화
+    case RESET_TO_SGG_DISTRICT:
+      return {
+        data: {
+          ...state.data,
+          level: 2,
+          sidoName: action.payload.sidoName,
+          sggName: "",
+          geojsonData: action.payload.geojson,
+          cdrCentersInfo: null,
+        },
+      };
+
     // 마커 클릭 이벤트
     case MARKER_Click:
       return {

--- a/app/src/modules/mapboxEvent.js
+++ b/app/src/modules/mapboxEvent.js
@@ -251,6 +251,7 @@ export default function mapboxEventReducer(state = initialState, action) {
         data: {
           ...state.data,
           level: 1,
+          popupInfo: null,
           sidoName: "",
           sggName: "",
           geojsonData: action.payload,
@@ -263,6 +264,7 @@ export default function mapboxEventReducer(state = initialState, action) {
         data: {
           ...state.data,
           level: 2,
+          popupInfo: null,
           sidoName: action.payload.sidoName,
           sggName: "",
           geojsonData: action.payload.geojson,

--- a/app/src/modules/mapboxEvent.js
+++ b/app/src/modules/mapboxEvent.js
@@ -6,7 +6,7 @@ const SIDO_CLICK = "mapboxEvent/SIDO_CLICK";
 const SGG_CLICK = "mapboxEvent/SGG_CLICK";
 const RESET_TO_SIDO_DISTRICT = "mapboxEvent/RESET_TO_SIDO_DISTRICT";
 const RESET_TO_SGG_DISTRICT = "mapboxEvent/RESET_TO_SGG_DISTRICT";
-const MARKER_Click = "mapboxEvent/MARKER_Click";
+const MARKER_CLICK = "mapboxEvent/MARKER_CLICK";
 const ERROR = "mapboxEvent/ERROR";
 
 /**
@@ -179,7 +179,7 @@ export const markerClick = (markerInfo) => async (dispatch) => {
     swoonCount: markerInfo.swoon_count,
     anomalyCount: markerInfo.anomaly_count,
   };
-  dispatch({ type: MARKER_Click, payload: popupInfo });
+  dispatch({ type: MARKER_CLICK, payload: popupInfo });
 };
 
 const initialState = {
@@ -273,7 +273,7 @@ export default function mapboxEventReducer(state = initialState, action) {
       };
 
     // 마커 클릭 이벤트
-    case MARKER_Click:
+    case MARKER_CLICK:
       return {
         data: {
           ...state.data,

--- a/app/src/styles/components/_mapbox.scss
+++ b/app/src/styles/components/_mapbox.scss
@@ -27,12 +27,3 @@
     height: 3rem;
   }
 }
-.reset-button {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: absolute;
-  top: 205px;
-  left: 220px;
-  z-index: 5;
-}

--- a/app/src/styles/components/_mapbox.scss
+++ b/app/src/styles/components/_mapbox.scss
@@ -1,5 +1,4 @@
 .popup {
-  z-index: 10;
   font-size: 0.9rem;
   padding: 0;
 
@@ -25,5 +24,34 @@
   &:hover {
     width: 2rem;
     height: 3rem;
+  }
+}
+.noResult-modal {
+  display: flex;
+  position: absolute;
+  top: 15px;
+  left: 15px;
+  justify-content: center;
+  align-items: center;
+  width: calc(100% - 30px);
+  height: calc(100% - 30px);
+  background-color: rgba(0, 0, 0, 0.3);
+
+  section {
+    display: flex;
+    text-align: center;
+    width: 280px;
+    flex-direction: column;
+    padding: 20px;
+    background-color: white;
+    border-radius: 10px;
+    font-size: 1.2rem;
+    font-weight: 600;
+    z-index: 5;
+    animation: modal-sliding 0.4s ease-in-out;
+
+    button {
+      margin-top: 15px;
+    }
   }
 }

--- a/app/src/styles/components/_mapboxCategory.scss
+++ b/app/src/styles/components/_mapboxCategory.scss
@@ -26,4 +26,8 @@
       margin-right: 10px;
     }
   }
+  .reset-button {
+    margin-top: 15px;
+    width: 100%;
+  }
 }

--- a/app/src/styles/components/_mapboxCategory.scss
+++ b/app/src/styles/components/_mapboxCategory.scss
@@ -26,7 +26,9 @@
       margin-right: 10px;
     }
   }
-  .reset-button {
+  .control-button {
+    display: flex;
+    justify-content: space-between;
     margin-top: 15px;
     width: 100%;
   }

--- a/app/src/styles/components/_modal.scss
+++ b/app/src/styles/components/_modal.scss
@@ -10,7 +10,7 @@
 .modal {
   display: flex;
   width: 100vw;
-  height: 100vh;
+  height: 100%;
   justify-content: center;
   align-items: center;
   top: 0;


### PR DESCRIPTION
# 기능 Issue
Linked Feature backlog : #KDSK-127

## PR 목적

- 본 PR에서는 /monitoring 페이지의 지도와 컨트롤러 기능을 보완합니다.
   
## 작업 설명

- 기존 리셋 버튼의 스타일을 수정합니다.
- 기존 리셋 버튼을 도, 광역시 기준과 시,군,구 기준으로 리셋할 수 있는 버튼으로 분할합니다.
- 어린이집을 검색했을 때 결과가 없다면(=개수 0) 검색 결과 없음을 알리는 모달창을 출력합니다.

## 라벨링 확인
작업 우선순위 : 중
