### PR TITLE
#KDSK-132 제주시, 세종시 cctv seeder 보강

### DIFF
--- a/server/database/data_parsers/cctvs.js
+++ b/server/database/data_parsers/cctvs.js
@@ -1,7 +1,13 @@
 let centerInfo = require('../../../.dummy/child_care_center.json');
+const jejuCenterInfo = require('../../../.dummy/jeju_child_care_center.json');
+const sejongCenterInfo = require('../../../.dummy/sejong_child_care_center.json');
 const { v4: uuidv4 } = require('uuid');
 const fs = require('fs');
-var keys = Object.keys(centerInfo);
+
+// 전체, 제주시, 세종시 데이터 합치기
+Object.assign(centerInfo, jejuCenterInfo, sejongCenterInfo);
+
+const keys = Object.keys(centerInfo);
 
 // 난수 생성 함수
 function makeRandomNumber(divisor) {
@@ -25,24 +31,24 @@ function randomMac() {
 function randomCenter() {
   let target = makeRandomNumber(keys.length);
   let center_id = centerInfo[keys[target]][0];
-  let center_name = String(centerInfo[keys[target]][2] + '_1'); // 띄어쓰기 있을 수 있음
+  let center_name = String(centerInfo[keys[target]][2] + '_1');
   return [center_id, center_name];
 }
 
 var cctvs = [];
 
 for (let i = 0; i < 1000; i++) {
-  let [cctv_id, cctv_name] = randomCenter();
+  let [center_id, cctv_name] = randomCenter();
   cctvs.push({
     cctv_id: uuidv4(),
     cctv_name: cctv_name,
     cctv_mac: randomMac(),
     quality: 'HD',
-    install_date: '2021-08-20',
-    center_id: cctv_id,
+    install_date: '2021-08-20', // 500cctvs의 경우 2021-08-24
+    center_id: center_id,
   });
 }
 
 const cctvJson = JSON.stringify(cctvs);
-fs.writeFileSync('1000cctvs.json', cctvJson);
+fs.writeFileSync('1000cctvs.json', cctvJson); // 500cctvs_jeju_sejong.json
 exports.cctvs = cctvs;

--- a/server/database/seeders/20210824074514-500cctvs_jeju_sejong.js
+++ b/server/database/seeders/20210824074514-500cctvs_jeju_sejong.js
@@ -1,0 +1,16 @@
+'use strict';
+const fs = require('fs');
+
+const cctvsBuffer = fs.readFileSync('../../.dummy/500cctvs_jeju_sejong.json');
+const cctvsJson = cctvsBuffer.toString();
+const cctvs = JSON.parse(cctvsJson);
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.bulkInsert('cctv', cctvs);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('cctv', { install_date: ['2021-08-24'] });
+  },
+};


### PR DESCRIPTION
# 기능 Issue
Linked Feature backlog : #KDSK- 132

## PR 목적

- 본 PR에서는 anomaly data생성을 위해 빠진 제주시, 세종시 cctv seeder를 보강합니다.
   
## 작업 설명

- 제주시, 세종시 어린이집 수의 합계가 약 1100건이라 500개의 어린이집을 선정해 `500cctvs_jeju_sejong.json`파일을 생성하였습니다. 
- 고로 `1000cctvs.json`, `500cctvs_jeju_sejong.json` 2개의 파일에 cctv테이블의 seeder 데이터가 있는 것이지만 이런 파일들을 생성하는 파일은 `cctvs.js` 하나로 관리하고 있습니다.
-  cctv 테이블에 seeder는 삽입한 상태이고 해당 파일은 스케쥴러 돌려 anomaly data를 뽑을 수 있도록 상일님께 전송하였습니다!

## 라벨링 확인
작업 우선순위 : 중
